### PR TITLE
Declared return type of InjectValueExtension::expand doesn't match real return value

### DIFF
--- a/src/Extension/InjectValueExtension.php
+++ b/src/Extension/InjectValueExtension.php
@@ -69,7 +69,10 @@ class InjectValueExtension extends CompilerExtension
 		}
 	}
 
-	protected function expand(string $value): string
+	/**
+	 * @return mixed
+	 */
+	protected function expand(string $value)
 	{
 		return Helpers::expand($value, $this->compiler->getConfig()['parameters']);
 	}


### PR DESCRIPTION
InjectValueExtension::expand states its return value as string, but it returns the result of Helpers::expand which is mixed. This causes a TypeError when the value being injected is for e.g a number.
Proposed solution is to remove a return type definition (makes it match the Helpers::expand return type).